### PR TITLE
Enable editing a post from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ This slimness makes Journey an ideal candidate for setting up micro blogs or hos
 ## Installing Journey
 To get started with Journey, go to the the [Releases Page](https://github.com/kabukky/journey/releases) and download the zip file corresponding to your operating system and cpu architecture. Then extract Journey anywhere you like. Why not place it in your home folder (e.g. /home/youruser/journey/)?
 
-After that, head over to [Setting up Journey](https://github.com/kabukky/journey/wiki/Setting-up-Journey) to configure your Journey blog on your local machine. If you'd like to set up Journey on a linux server, head over to [Installing Journey on Ubuntu Server](https://github.com/kabukky/journey/wiki/Installing-Journey-on-Ubuntu-Server) for a step-by-step tutorial.
+After that, head over to [Setting up Journey](https://github.com/kabukky/journey/wiki/Setting-up-Journey) to configure your Journey blog on your local machine.
+
+If you'd like to set up Journey on a Linux server, head over to [Installing Journey on Ubuntu Server](https://github.com/kabukky/journey/wiki/Installing-Journey-on-Ubuntu-Server) for a step-by-step tutorial.
+
+Journey even runs as a Windows Azure Web App. It's a great way to try out or host a low traffic Journey blog for free on the internet! Head over to [Hosting Journey as a Windows Azure Web App](https://github.com/kabukky/journey/wiki/Hosting-Journey-as-a-Windows-Azure-Web-App) for a step-by-step tutorial.
 
 ## Plugins
 Did you create a Journey plugin? Write me [@kabukky](https://twitter.com/kabukky) or me@kaihag.com and I'll add a link to it here.

--- a/built-in/admin/admin-angular.js
+++ b/built-in/admin/admin-angular.js
@@ -1,27 +1,29 @@
-//register the modules (don't forget ui bootstrap and bootstrap switch)
+// TODO: Split this Angular app into a proper directory structure
+
+//register the modules
 var adminApp = angular.module('adminApp', ['ngRoute', 'frapontillo.bootstrap-switch', 'ui.bootstrap', 'infinite-scroll']);
 
 adminApp.config(function($routeProvider) {
-	$routeProvider.
-		when('/', {
-			templateUrl: 'content.html',
-			controller: 'ContentCtrl'
-		}).
-		when('/edit/:Id', {
-			templateUrl: 'post.html',
-			controller: 'EditCtrl'
-		}).
-		when('/create/', {
-			templateUrl: 'post.html',
-			controller: 'CreateCtrl'
-		}).
+  $routeProvider.
+    when('/', {
+      templateUrl: 'content.html',
+      controller: 'ContentCtrl'
+    }).
+    when('/edit/:Id', {
+      templateUrl: 'post.html',
+      controller: 'EditCtrl'
+    }).
+    when('/create/', {
+      templateUrl: 'post.html',
+      controller: 'CreateCtrl'
+    }).
     when('/settings/', {
       templateUrl: 'settings.html',
       controller: 'SettingsCtrl'
     }).
-		otherwise({
-        	redirectTo: '/'
-	});
+    otherwise({
+          redirectTo: '/'
+  });
 });
 
 //service for sharing the markdown content across controllers
@@ -176,9 +178,9 @@ adminApp.controller('CreateCtrl', function ($scope, $http, $sce, $location, shar
   var converter = new Showdown.converter();
   //change the navbar according to controller
   $scope.navbarHtml = $sce.trustAsHtml('<ul class="nav navbar-nav"><li><a href="#/">Content</a></li><li class="active"><a href="#/create/">New Post<span class="sr-only">(current)</span></a></li><li><a href="#/settings/">Settings</a></li><li><a href="logout/" class="logout">Log Out</a></li></ul>');
-	$scope.shared = sharingService.shared;
+  $scope.shared = sharingService.shared;
   $scope.shared.post = {Title: 'New Post', Slug: '', Markdown: 'Write something!', IsPublished: false, Image: '', Tags: ''}
-	$scope.change = function() {
+  $scope.change = function() {
     document.getElementById('html-div').innerHTML = '<h1>' + $scope.shared.post.Title + '</h1><br>' + converter.makeHtml($scope.shared.post.Markdown);
     //resize the markdown textarea
     $('.textarea-autosize').val($scope.shared.post.Markdown).trigger('autosize.resize');
@@ -203,12 +205,12 @@ adminApp.controller('EditCtrl', function ($scope, $routeParams, $http, $sce, $lo
     //resize the markdown textarea
     $('.textarea-autosize').val($scope.shared.post.Markdown).trigger('autosize.resize');
   };
-	$http.get('/admin/api/post/' + $routeParams.Id).success(function(data) {
-		$scope.shared.post = data;
+  $http.get('/admin/api/post/' + $routeParams.Id).success(function(data) {
+    $scope.shared.post = data;
     $scope.change();
   });
   $scope.save = function() {
-  	$http.patch('/admin/api/post', $scope.shared.post).success(function(data) {
+    $http.patch('/admin/api/post', $scope.shared.post).success(function(data) {
       $location.url('/');
     });
   };
@@ -245,7 +247,7 @@ adminApp.controller('EmptyModalCtrl', function ($scope, $modal, $http, sharingSe
 
 //modal for image selection and upload
 adminApp.controller('ImageModalCtrl', function ($scope, $modal, $http, sharingService, infiniteScrollFactory) {
-	$scope.shared = sharingService.shared;
+  $scope.shared = sharingService.shared;
   $scope.shared.infiniteScrollFactory = new infiniteScrollFactory('/admin/api/images/');
   $scope.shared.infiniteScrollFactory.nextPage();
   $scope.open = function (size, callingFrom) {

--- a/filenames/filenames.go
+++ b/filenames/filenames.go
@@ -13,7 +13,7 @@ var (
 	ExecutablePath = determineExecutablePath()
 
 	// Determine the path the the assets folder (default: Journey root folder)
-	AssetPath = determineContentPath()
+	AssetPath = determineAssetPath()
 
 	// For assets that are created, changed, our user-provided while running journey
 	ConfigFilename   = filepath.Join(AssetPath, "config.json")
@@ -71,7 +71,7 @@ func createDirectories() error {
 	return nil
 }
 
-func determineContentPath() string {
+func determineAssetPath() string {
 	contentPath := ""
 	if flags.CustomPath != "" {
 		contentPath = flags.CustomPath

--- a/server/blog.go
+++ b/server/blog.go
@@ -1,13 +1,16 @@
 package server
 
 import (
-	"github.com/dimfeld/httptreemux"
-	"github.com/kabukky/journey/filenames"
-	"github.com/kabukky/journey/structure/methods"
-	"github.com/kabukky/journey/templates"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
+
+	"github.com/dimfeld/httptreemux"
+	"github.com/kabukky/journey/database"
+	"github.com/kabukky/journey/filenames"
+	"github.com/kabukky/journey/structure/methods"
+	"github.com/kabukky/journey/templates"
 )
 
 func indexHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
@@ -119,6 +122,7 @@ func postHandler(w http.ResponseWriter, r *http.Request, params map[string]strin
 		}
 		return
 	}
+
 	// Render post template
 	err := templates.ShowPostTemplate(w, r, slug)
 	if err != nil {
@@ -126,6 +130,24 @@ func postHandler(w http.ResponseWriter, r *http.Request, params map[string]strin
 		return
 	}
 	return
+}
+
+func postEditHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
+	slug := params["slug"]
+
+	if slug == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	// Redirect to edit
+	post, err := database.RetrievePostBySlug(slug)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	url := fmt.Sprintf("/admin/#/edit/%d", post.Id)
+	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
 
 func assetsHandler(w http.ResponseWriter, r *http.Request, params map[string]string) {
@@ -149,6 +171,7 @@ func publicHandler(w http.ResponseWriter, r *http.Request, params map[string]str
 func InitializeBlog(router *httptreemux.TreeMux) {
 	// For index
 	router.GET("/", indexHandler)
+	router.GET("/:slug/edit", postEditHandler)
 	router.GET("/:slug/", postHandler)
 	router.GET("/page/:number/", indexHandler)
 	// For author


### PR DESCRIPTION
In Ghost, when viewing a blog post you can append "/edit" to the end of the url to edit it (assuming you're logged in). This adds that ability to Journey. The only problem I found was as follows.
1. User is not logged in
2. User  appends /edit to blog url
3. User gets sent to login page
4. User logs in
5. User sees admin page instead of going to edit post page

This is caused by the usage of the # fragment which isn't carried across the login page. I tinkered with fixing it but [r.URL.Fragment](https://golang.org/pkg/net/url/) was always empty in all handlers. I imagine this is a good first step even without that.
