### PR TITLE
Adding ability to use relative paths and added helper to handle tilde…

### DIFF
--- a/filenames/filenames.go
+++ b/filenames/filenames.go
@@ -6,13 +6,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
 	// Determine the path the Journey executable is in - needed to load relative assets
 	ExecutablePath = determineExecutablePath()
 
-	// Determine the path the the assets folder (default: Journey root folder)
+	// Determine the path to the assets folder (default: Journey root folder)
 	AssetPath = determineAssetPath()
 
 	// For assets that are created, changed, our user-provided while running journey
@@ -68,14 +69,22 @@ func createDirectories() error {
 	return nil
 }
 
-func determineAssetPath() string {
-	contentPath := ""
-	if flags.CustomPath != "" {
-		contentPath = flags.CustomPath
-	} else {
-		contentPath = determineExecutablePath()
+func bashPath(contentPath string) string {
+	if strings.HasPrefix(contentPath, "~") {
+		return strings.Replace(contentPath, "~", os.Getenv("HOME"), 1)
 	}
 	return contentPath
+}
+
+func determineAssetPath() string {
+	if flags.CustomPath != "" {
+		contentPath, err := filepath.Abs(bashPath(flags.CustomPath))
+		if err != nil {
+			log.Fatal("Error: Couldn't read from custom path:", err)
+		}
+		return contentPath
+	}
+	return determineExecutablePath()
 }
 
 func determineExecutablePath() string {


### PR DESCRIPTION
`.`, `..`, and `~` were not being handled for `-custom-path`.  This change adds a helper for handling `~` by converting to `os.Getenv("HOME")` as well as stretching `contentPath` to absolute path.  This change fixes @johnjelinek's issue on #12.
